### PR TITLE
fix: modal-overflow

### DIFF
--- a/src/components/EditField/index.js
+++ b/src/components/EditField/index.js
@@ -38,7 +38,7 @@ const EditField = ({
   const [field] = useField({ id, name })
 
   return (
-    <section>
+    <>
       <div className={style.header}>
         {label && (
           <Typography weight="bold" variant="body1">
@@ -58,7 +58,7 @@ const EditField = ({
           <Typography variant="body2">{description}</Typography>
         </Tooltip>
       )}
-    </section>
+    </>
   )
 }
 

--- a/src/components/TokenPicker/index.js
+++ b/src/components/TokenPicker/index.js
@@ -1,10 +1,6 @@
 import React, { useMemo } from 'react'
 import T from 'prop-types'
-import {
-  useLoadUniswapPairs,
-  useEthosContext,
-  useWeb3,
-} from '@ethereansos/interfaces-core'
+import { useLoadUniswapPairs } from '@ethereansos/interfaces-core'
 import { useField, useFormikContext } from 'formik'
 
 import { Select } from '../../design-system'
@@ -12,17 +8,10 @@ import { Select } from '../../design-system'
 import style from './token-picker.module.scss'
 
 const TokenPicker = ({ tokenAddress, id, name }) => {
-  const { networkId, web3, web3ForLogs } = useWeb3()
-  const context = useEthosContext()
-
   const [{ onChange, ...field }] = useField({ id, name })
   const { setFieldValue } = useFormikContext()
 
-  const uniswapPairs = useLoadUniswapPairs(
-    { web3, context, networkId, web3ForLogs },
-    tokenAddress,
-    undefined
-  )
+  const uniswapPairs = useLoadUniswapPairs(tokenAddress)
 
   const options = useMemo(
     () =>

--- a/src/design-system/Modal/modal.module.scss
+++ b/src/design-system/Modal/modal.module.scss
@@ -1,8 +1,10 @@
 .root {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
+  bottom: 0;
   min-height: 100vh;
   background-color: var(--color-background-dark);
+  overflow: auto;
 }


### PR DESCRIPTION
Remove usage of web3 core hooks inside the token picker component.
Enable the modal to have its own scrollbar if the content exceed the viewport