### PR TITLE
fix: add proper label and values to the token picker

### DIFF
--- a/src/components/TokenPicker/index.js
+++ b/src/components/TokenPicker/index.js
@@ -16,8 +16,10 @@ const TokenPicker = ({ tokenAddress, id, name }) => {
   const options = useMemo(
     () =>
       uniswapPairs.map((pair) => ({
-        id: pair.address,
-        label: `${pair.name} ${pair.symbol}`,
+        id: pair?.token1?.address || pair.address,
+        label: pair?.token1?.name
+          ? `${pair.token1.name} (${pair.token1.symbol})`
+          : pair.symbol,
       })),
     [uniswapPairs]
   )


### PR DESCRIPTION
The token picker was retrieving some incorrect values when used inside the swapping functionality